### PR TITLE
Better error display and recovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,14 +23,15 @@
 
 You need to pass the following query params in the URL:
 
-| Param            | Example                                 | Description                                                                       |
-| ---------------- | --------------------------------------- | --------------------------------------------------------------------------------- |
-| `token`          | _generated UUID_                        | **Required**: Get this from the `abstractrrr tokens` command                      |
-| `broadcaster_id` | `123456789`                             | **Required**: Twitch user ID for the streamer user of the Abstractrrr token       |
-| `host`           | `localhost` (default) or `192.168.0.15` | _(optional)_: Host that abstractrrr is running on.                                |
-| `port`           | `9999` (default)                        | _(optional)_: Port that abstractrrr is running on.                                |
-| `time_ms`        | `5000` (default)                        | _(optional)_: Time in milliseconds that each chat message should be displayed for |
-| `debug`          | `1` or `0`                              | _(optional)_: Provides extra logging                                              |
+| Param            | Example                                 | Description                                                                                                                                               |
+| ---------------- | --------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `token`          | _generated UUID_                        | **Required**: Get this from the `abstractrrr tokens` command                                                                                              |
+| `broadcaster_id` | `123456789`                             | **Required**: Twitch user ID for the streamer user of the Abstractrrr token                                                                               |
+| `host`           | `localhost` (default) or `192.168.0.15` | _(optional)_: Host that abstractrrr is running on.                                                                                                        |
+| `port`           | `9999` (default)                        | _(optional)_: Port that abstractrrr is running on.                                                                                                        |
+| `time_ms`        | `5000` (default)                        | _(optional)_: Time in milliseconds that each chat message should be displayed for                                                                         |
+| `debug`          | `1` or `0`                              | _(optional)_: Provides extra logging                                                                                                                      |
+| `hide_error`     | `1` or `0` (default: 0)                 | _(optional)_: Hides the error in the event of a networking event. Configuration errors will still display (e.g. if you don't provide required parameters) |
 
 Here is an example URL with the hosted version if you'd like to use the one I use:
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -136,6 +136,12 @@ const initChatConnection = async ({
     // if a retry is already in progress, clear it and make a new one
     if (typeof retryTimeoutId.value === 'number') {
       clearTimeout(retryTimeoutId.value)
+
+      if (retryCount.value > MAX_RETRIES) {
+        console.error(`retries exhausted at ${retryCount.value} attempts`)
+        clearTimeout(retryTimeoutId.value)
+        return
+      }
     }
 
     // increment the retry count

--- a/src/utils/networking-utils.ts
+++ b/src/utils/networking-utils.ts
@@ -10,6 +10,7 @@ export const connectToChat = ({
   onError,
   onClose,
   onClearChat,
+  onConnect,
 }: {
   port: string;
   token: string;
@@ -18,6 +19,7 @@ export const connectToChat = ({
   onChat: (irc_data: IRCData) => void;
   onError: (event: Event) => void;
   onClose: (event: CloseEvent) => void;
+  onConnect: (event: Event) => void;
 }) => {
   const debug = debugModeFromURL()
 
@@ -73,13 +75,14 @@ export const connectToChat = ({
     }
   });
 
-  socket.addEventListener("open", (_event) => {
+  socket.addEventListener("open", (event) => {
     // Send the auth token
     if (debug) {
       console.log("Sending token payload:", { token });
     }
 
     socket.send(JSON.stringify({ token }));
+    onConnect(event)
   });
 };
 

--- a/src/utils/networking-utils.ts
+++ b/src/utils/networking-utils.ts
@@ -82,3 +82,14 @@ export const connectToChat = ({
     socket.send(JSON.stringify({ token }));
   });
 };
+
+
+export type AbstractrrrHealthResponse = {
+  data: {
+    date: string;
+    service: string;
+  }
+  meta: {
+    request_id: string;
+  }
+}

--- a/src/utils/url-utils.ts
+++ b/src/utils/url-utils.ts
@@ -36,6 +36,13 @@ export function debugModeFromURL(): boolean {
   return value === "true" || value === "1" || value === "yes";
 }
 
+export function shouldHideErrorConfigFromURL(): boolean {
+  const params = new URLSearchParams(location.search);
+  const value = (params.get("hide_error") || "").toLowerCase()
+
+  return value === "true" || value === "1" || value === "yes";
+}
+
 export function messageVisibilityMilliseconds(): number {
   const defaultMillis = 5000
 


### PR DESCRIPTION
Better error display:

<img width="459" alt="image" src="https://github.com/techygrrrl/twitch-horizontal-chat-overlay-pronouns/assets/88961088/671de204-a942-418a-a46d-9b634193201b">

Retry functionality:

- retries 20 times if it fails to connect to the abstractrrr health check endpoint
- retries every 500ms
- resets the retry count when the client successfully connects
- retries when the connection drops after a successful connection (when the websocket connection closes)

So essentially 2 checks trigger retry functionality:

- failed health check
- closed web socket connection